### PR TITLE
add more verbosity to error message

### DIFF
--- a/tfimm/train/config.py
+++ b/tfimm/train/config.py
@@ -393,7 +393,8 @@ def parse_args(cfg, *, cfg_class=None, args=None):
             raise ValueError(
                 "During the last parsing we have not reduced the number of unparsed "
                 "arguments. This suggests that either the user has supplied unknown "
-                "arguments or that a '_class' argument is missing."
+                "arguments or that a '_class' argument is missing.\n"
+                f"The list of unparsed arguments is {unparsed}."
             )
         nb_unparsed = len(unparsed)
 


### PR DESCRIPTION
It's a very small PR but it addresses an issue I had recently. I would like to add more verbosity to the error message for config file. Then the user would be aware of the faulty arguments.