### PR TITLE
New feature: Loading weights of fine-tuned timm model to keras

### DIFF
--- a/notebooks/load_pretrained_timm.ipynb
+++ b/notebooks/load_pretrained_timm.ipynb
@@ -1,0 +1,155 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example of loading the weights of a trained timm model to keras"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### import libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'\n",
+    "\n",
+    "import timm\n",
+    "import tfimm\n",
+    "import tensorflow as tf\n",
+    "import torch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Define the timm model parameters\n",
+    "I will use ViT model, you can use any models supported by tfimm (link to these models is <a href='https://github.com/martinsbruveris/tensorflow-image-models#models'>here</a>)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TIMM_MODEL_NAME = 'vit_tiny_patch16_224'\n",
+    "N_CLASSES = 5\n",
+    "IMG_DIM = 224"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "I will create a model using timm, you can also load your custom weights"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "timm_model = timm.create_model(model_name=TIMM_MODEL_NAME, num_classes=N_CLASSES, pretrained=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Creating keras model using weights from the pretrained timm\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "keras_model = tfimm.load_timm_model(TIMM_MODEL_NAME, nb_classes=N_CLASSES, pt_model=timm_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Testing models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sample_input = torch.rand((2,3,IMG_DIM,IMG_DIM))\n",
+    "torch_output = timm_model(sample_input).detach().numpy()\n",
+    "keras_output = keras_model.predict(sample_input.permute(0,2,3,1).numpy())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(torch_output)\n",
+    "print(keras_output)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Save keras model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "keras_model.save(filepath=f'keras_{TIMM_MODEL_NAME}', save_format='tf')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.8.12 ('py38')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "cbf31710a13b3f828814fd14bbb297f0414df26fd4c4d0b3a66d9340eb05c999"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tfimm/__init__.py
+++ b/tfimm/__init__.py
@@ -1,5 +1,5 @@
 from . import architectures  # noqa: F401
-from .models.factory import create_model, create_preprocessing  # noqa: F401
+from .models.factory import create_model, create_preprocessing, load_timm_model  # noqa: F401
 from .models.registry import list_models  # noqa: F401
 from .utils import (  # noqa: F401
     cached_model_path,


### PR DESCRIPTION
So far, `tfimm` allows to create and initialize keras models using default `timm` weights as follows:
`tfimm.create_model(TIMM_MODEL_NAME, pretrained="timm")`

It is also useful to be able to load a fine-tuned `timm` model. This is what I implemented and would like to see in the future releases. I also added a Jupyter notebook to demonstrate usage.