### PR TITLE
Convnext tags

### DIFF
--- a/docs/source/content/models.rst
+++ b/docs/source/content/models.rst
@@ -8,3 +8,10 @@ Creating models
 
 .. autofunction:: create_model
 .. autofunction:: create_preprocessing
+
+Model registry
+--------------
+
+.. py:module:: tfimm.models.registry
+
+.. autofunction:: register_model

--- a/tests/models/test_registry.py
+++ b/tests/models/test_registry.py
@@ -1,0 +1,24 @@
+import pytest
+
+from tfimm.models.registry import _split_model_name, _update_cfg_url
+
+
+@pytest.mark.parametrize(
+    "full_name, model_name, model_tag",
+    [("a.b", "a", "b"), ("a", "a", ""), ("a.b.c", "a", "b.c")],
+)
+def test_split_model_name(full_name, model_name, model_tag):
+    assert _split_model_name(full_name) == (model_name, model_tag)
+
+
+@pytest.mark.parametrize(
+    "url, model_name, model_tag, expected",
+    [
+        ("[timm]pt", "tf", "tag", "[timm]pt.tag"),
+        ("[timm]pt.old", "tf", "tag", "[timm]pt.tag"),
+        ("[timm]", "tf", "tag", "[timm]tf.tag"),
+        ("[not-timm]", "tf", "tag", "[not-timm]"),
+    ],
+)
+def test_update_cfg_url(url, model_name, model_tag, expected):
+    assert _update_cfg_url(url, model_name, model_tag) == expected

--- a/tfimm/models/registry.py
+++ b/tfimm/models/registry.py
@@ -60,6 +60,11 @@ def register_model(fn):
 
 
 def _natural_key(string_):
+    """
+    Converts string to list of strings and numbers, i.e.,
+        "abc123xyz" -> ["abc", 123, "xyz"]
+    to obtain a more natural sort order: "resnet34" comes before "resnet101".
+    """
     return [int(s) if s.isdigit() else s for s in re.split(r"(\d+)", string_.lower())]
 
 
@@ -69,7 +74,8 @@ def list_models(
     pretrained: Union[bool, str] = False,
     exclude_filters: Union[str, List[str]] = "",
 ):
-    """Returns list of available model names, sorted alphabetically.
+    """
+    Returns list of available model names, sorted alphabetically.
 
     Args:
         name_filter: Wildcard filter string that works with fnmatch
@@ -117,28 +123,30 @@ def list_models(
 
 
 def is_model(model_name):
-    """Check if a model name exists"""
+    """Check if a model name exists."""
     return model_name in _model_class
 
 
 def model_class(model_name):
-    """Fetch a model entrypoint for specified model name"""
+    """Fetch a model entrypoint for specified model name."""
     return _model_class[model_name]
 
 
 def model_config(model_name):
-    """Fetch a model config for specified model name"""
+    """Fetch a model config for specified model name."""
     return _model_config[model_name]
 
 
 def list_modules():
-    """Return list of module names that contain models / model entrypoints"""
+    """Return list of module names that contain models / model entrypoints."""
     modules = _module_to_models.keys()
     return list(sorted(modules))
 
 
 def is_model_in_modules(model_name, module_names):
-    """Check if a model exists within a subset of modules
+    """
+    Check if a model exists within a subset of modules
+
     Args:
         model_name (str) - name of model to check
         module_names (tuple, list, set) - names of modules to search in


### PR DESCRIPTION
Adding support for model names of the form `model_name.model_tag` as adopted by `timm` and adding the new ConNeXt architectures now available in `timm`.