### PR TITLE
Lora create model

### DIFF
--- a/tfimm/architectures/lora/__init__.py
+++ b/tfimm/architectures/lora/__init__.py
@@ -1,0 +1,1 @@
+from .factory import create_model

--- a/tfimm/architectures/lora/__init__.py
+++ b/tfimm/architectures/lora/__init__.py
@@ -1,3 +1,7 @@
-from .convnext import *
-from .factory import create_model, mark_only_lora_as_trainable
-from .registry import register_lora_architecture, lora_config, lora_architecture
+from .convnext import *  # noqa: F401
+from .factory import create_model, mark_only_lora_as_trainable  # noqa: F401
+from .registry import (  # noqa: F401
+    lora_architecture,
+    lora_config,
+    register_lora_architecture,
+)

--- a/tfimm/architectures/lora/__init__.py
+++ b/tfimm/architectures/lora/__init__.py
@@ -1,1 +1,3 @@
+from .convnext import *
 from .factory import create_model
+from .registry import register_lora_architecture, lora_config, lora_architecture

--- a/tfimm/architectures/lora/__init__.py
+++ b/tfimm/architectures/lora/__init__.py
@@ -1,3 +1,3 @@
 from .convnext import *
-from .factory import create_model
+from .factory import create_model, mark_only_lora_as_trainable
 from .registry import register_lora_architecture, lora_config, lora_architecture

--- a/tfimm/architectures/lora/convnext.py
+++ b/tfimm/architectures/lora/convnext.py
@@ -6,6 +6,8 @@ from tfimm.architectures.convnext import ConvNeXt, ConvNeXtConfig
 from tfimm.models import keras_serializable
 from .registry import register_lora_architecture
 
+__all__ = ["LoRAConvNeXt", "LoRAConvNeXtConfig"]
+
 
 # TODO: This is temporary...
 class LoraDense(tf.keras.layers.Dense):
@@ -14,12 +16,14 @@ class LoraDense(tf.keras.layers.Dense):
         self.lora_weight = None
 
     def build(self, input_shape):
+        super().build(input_shape)
         self.lora_weight = self.add_weight(
             name="lora_weight",
             shape=(1,),
             initializer=tf.keras.initializers.constant(0.0),
             trainable=True,
         )
+
 
     def call(self, x):
         return super().call(x + self.lora_weight)
@@ -28,7 +32,7 @@ class LoraDense(tf.keras.layers.Dense):
 @dataclass
 class LoRAConvNeXtConfig(ConvNeXtConfig):
     lora_rank: int = 2
-    lora_alpha: float = 1.0  # TODO: Find better default value
+    lora_alpha: float = 1.0
 
 
 
@@ -36,6 +40,10 @@ class LoRAConvNeXtConfig(ConvNeXtConfig):
 @register_lora_architecture
 class LoRAConvNeXt(ConvNeXt):
 
+    # TODO (martins): I should rewrite the `transfer_weights` function to iterate over
+    #   src weights instead of dst weights. In that case we wouldn't need to add
+    #   lora_weights here.
+    keys_to_ignore_on_load_missing = ["lora_weight"]
     cfg_class = LoRAConvNeXtConfig
 
     def __init__(self, cfg: LoRAConvNeXtConfig, **kwargs):

--- a/tfimm/architectures/lora/convnext.py
+++ b/tfimm/architectures/lora/convnext.py
@@ -40,10 +40,6 @@ class LoRAConvNeXtConfig(ConvNeXtConfig):
 @register_lora_architecture
 class LoRAConvNeXt(ConvNeXt):
 
-    # TODO (martins): I should rewrite the `transfer_weights` function to iterate over
-    #   src weights instead of dst weights. In that case we wouldn't need to add
-    #   lora_weights here.
-    keys_to_ignore_on_load_missing = ["lora_weight"]
     cfg_class = LoRAConvNeXtConfig
 
     def __init__(self, cfg: LoRAConvNeXtConfig, **kwargs):

--- a/tfimm/architectures/lora/convnext.py
+++ b/tfimm/architectures/lora/convnext.py
@@ -1,0 +1,48 @@
+from dataclasses import dataclass
+
+import tensorflow as tf
+
+from tfimm.architectures.convnext import ConvNeXt, ConvNeXtConfig
+from tfimm.models import keras_serializable
+from .registry import register_lora_architecture
+
+
+# TODO: This is temporary...
+class LoraDense(tf.keras.layers.Dense):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.lora_weight = None
+
+    def build(self, input_shape):
+        self.lora_weight = self.add_weight(
+            name="lora_weight",
+            shape=(1,),
+            initializer=tf.keras.initializers.constant(0.0),
+            trainable=True,
+        )
+
+    def call(self, x):
+        return super().call(x + self.lora_weight)
+
+
+@dataclass
+class LoRAConvNeXtConfig(ConvNeXtConfig):
+    lora_rank: int = 2
+    lora_alpha: float = 1.0  # TODO: Find better default value
+
+
+
+@keras_serializable
+@register_lora_architecture
+class LoRAConvNeXt(ConvNeXt):
+
+    cfg_class = LoRAConvNeXtConfig
+
+    def __init__(self, cfg: LoRAConvNeXtConfig, **kwargs):
+        super().__init__(cfg, **kwargs)
+
+        for stage in self.stages:
+            for block in stage.blocks:
+                # TODO: Will need to adapt this to take into account LoRA parameters...
+                block.mlp.fc1 = LoraDense.from_config(block.mlp.fc1.get_config())
+                block.mlp.fc2 = LoraDense.from_config(block.mlp.fc2.get_config())

--- a/tfimm/architectures/lora/convnext.py
+++ b/tfimm/architectures/lora/convnext.py
@@ -4,6 +4,7 @@ import tensorflow as tf
 
 from tfimm.architectures.convnext import ConvNeXt, ConvNeXtConfig
 from tfimm.models import keras_serializable
+
 from .registry import register_lora_architecture
 
 __all__ = ["LoRAConvNeXt", "LoRAConvNeXtConfig"]
@@ -24,7 +25,6 @@ class LoraDense(tf.keras.layers.Dense):
             trainable=True,
         )
 
-
     def call(self, x):
         return super().call(x + self.lora_weight)
 
@@ -35,11 +35,9 @@ class LoRAConvNeXtConfig(ConvNeXtConfig):
     lora_alpha: float = 1.0
 
 
-
 @keras_serializable
 @register_lora_architecture
 class LoRAConvNeXt(ConvNeXt):
-
     cfg_class = LoRAConvNeXtConfig
 
     def __init__(self, cfg: LoRAConvNeXtConfig, **kwargs):

--- a/tfimm/architectures/lora/factory.py
+++ b/tfimm/architectures/lora/factory.py
@@ -1,0 +1,65 @@
+import dataclasses
+from typing import Optional
+
+import tensorflow as tf
+
+from tfimm.models import create_model as create_full_model
+from tfimm.models import model_config, model_class, transfer_weights
+from .registry import lora_architecture, lora_config
+
+
+def create_model(
+    model_name: str,
+    pretrained: bool = False,
+    model_path: str = "",
+    **kwargs,
+) -> tf.keras.Model:
+    """
+    Creates a LoRA model. This model will have all layers, except the LoRA layers set
+    to ``trainable=False``. For LoRA layers, only the low-rank adaptation weights will
+    be trainable.
+
+    Args:
+        model_name: Name of model to instantiate.
+        pretrained: If ``True``, load pretrained weights as specified by the ``url``
+            field in config. If ``url`` is ``[timm]``, the weights will be downloaded
+            from ``timm`` and converted to TensorFlow. See
+            :py:func:`tfimm.models.create_model` for details.
+        model_path: Path of model weights to load after model is initialized. This takes
+            over ``pretrained``.
+        **kwargs: LoRA parameters, such as ``lora_rank`` and ``lora_alpha`` need to be
+            passed as kwargs and will be added to the model config.
+
+    Returns:
+        The created model.
+    """
+    cls = model_class(model_name)
+    cfg = model_config(model_name)
+    lora_cls = lora_architecture(cls)
+    lora_cfg_cls = lora_config(cls)
+
+    # We split kwargs into LoRA-specific kwargs and all other ones. We only pass
+    # non-LoRA kwargs to create the original model.
+    full_model_kwargs = {k: v for k, v in kwargs.items() if not k.startswith("lora_")}
+    lora_kwargs = {k: v for k, v in kwargs.items() if k.startswith("lora_")}
+
+    full_model = create_full_model(
+        model_name=model_name,
+        pretrained=pretrained,
+        model_path=model_path,
+        **full_model_kwargs,
+    )
+
+    # Build LoRA model config by combining the original model config with LoRA kwargs.
+    lora_cfg = lora_cfg_cls(**dataclasses.asdict(cfg), **lora_kwargs)
+
+    # Instantiate LoRA model and build it
+    model = lora_cls(cfg=lora_cfg)
+    model(model.dummy_inputs)
+
+    # Transfer weights to LoRA model
+    transfer_weights(src_model=full_model, dst_model=model)
+
+    # Set all non-LoRA layers to trainable=False
+
+    return model

--- a/tfimm/architectures/lora/factory.py
+++ b/tfimm/architectures/lora/factory.py
@@ -16,15 +16,10 @@ def create_model(
     model_name: str,
     pretrained: bool = False,
     model_path: str = "",
-    *,
-    train_bias: str = "none",
     **kwargs,
 ) -> tf.keras.Model:
     """
-    Creates a LoRA model. This model will have all layers, except the LoRA layers set
-    to ``trainable=False``. For LoRA layers, only the low-rank adaptation weights will
-    be trainable. The only exception are bias weights, controlled by the behaviour of
-    ``train_bias``.
+    Creates a LoRA model.
 
     Args:
         model_name: Name of model to instantiate.
@@ -34,9 +29,6 @@ def create_model(
             :py:func:`tfimm.models.create_model` for details.
         model_path: Path of model weights to load after model is initialized. This takes
             over ``pretrained``.
-        train_bias: If "none" or "all", no or all bias weights are trainable
-            respectively. If "lora_only", only the bias weights of LoRA layers are set
-            to trainable.
         **kwargs: LoRA parameters, such as ``lora_rank`` and ``lora_alpha`` need to be
             passed as kwargs and will be added to the model config.
 
@@ -72,13 +64,25 @@ def create_model(
         src_model=full_model, dst_model=model, weights_to_ignore=["lora_weight"]
     )
 
-    # Set all non-LoRA layers to non-trainable
-    mark_only_lora_as_trainable(model, train_bias=train_bias)
-
     return model
 
 
 def mark_only_lora_as_trainable(model: tf.keras.Model, train_bias: str = "none"):
+    """
+    Marks only LoRA layers in the model as trainable. This model will have all layers,
+    except LoRA layers set to ``trainable=False``. For LoRA layers, only the low-rank
+    adaptation weights will be trainable. The only exception are bias weights,
+    controlled by the value of ``train_bias``.
+
+    Args:
+        model: Model to be modified.
+        train_bias: If "none" or "all", no or all bias weights are trainable
+            respectively. If "lora_only", only the bias weights of LoRA layers are set
+            to trainable.
+
+    Returns:
+        Nothing. The model is modified in place.
+    """
     if train_bias not in {"none", "all", "lora_only"}:
         raise ValueError(f"Unknown value for train_bias: {train_bias}.")
 

--- a/tfimm/architectures/lora/factory.py
+++ b/tfimm/architectures/lora/factory.py
@@ -2,8 +2,13 @@ import dataclasses
 
 import tensorflow as tf
 
-from tfimm.models import create_model as create_full_model
-from tfimm.models import model_config, model_class, transfer_weights
+from tfimm.models import (
+    create_model as create_full_model,
+    model_class,
+    model_config,
+    transfer_weights,
+)
+
 from .registry import lora_architecture, lora_config
 
 

--- a/tfimm/architectures/lora/registry.py
+++ b/tfimm/architectures/lora/registry.py
@@ -1,0 +1,53 @@
+import warnings
+
+# These dictionaries contain the mappings from model class to the corresponding LoRA
+# version of the model, i.e., "ConvNeXt" -> LoRAConvNeXt. The keys are the names of the
+# model class, while the values are the class and config class.
+#
+# Note that this is different from the model registry in `models/registry.py`, where
+# keys are specific model names, e.g., "convnext_tiny" and the config dictionary
+# contains concrete instances of the configuration classes.
+_lora_model_class = dict()
+_lora_model_config = dict()
+
+
+def register_lora_architecture(lora_cls):
+    # We assume that the LoRA architecture is a subclass of the original model class.
+    model_cls = lora_cls.__base__
+
+    model_name = model_cls.__name__
+    if model_name in _lora_model_class:
+        existing_lora_cls = _lora_model_class[model_name]
+        warnings.warn(
+            f"Model class {model_name} has already registered a LoRA version "
+            f"{existing_lora_cls.__name__}. Registering {lora_cls.__name__} will "
+            "overwrite this."
+        )
+
+    # We assume here that LoRA models have a `cfg_class` class attribute.
+    lora_cfg = lora_cls.cfg_class
+
+    _lora_model_class[model_name] = lora_cls
+    _lora_model_config[model_name] = lora_cfg
+
+    return lora_cls
+
+
+def lora_architecture(model_cls):
+    model_name = model_cls.__name__
+    if model_name not in _lora_model_class:
+        raise ValueError(
+            f"No LoRA variant has been registered for architecture {model_name}."
+        )
+    lora_cls = _lora_model_class[model_name]
+    return lora_cls
+
+
+def lora_config(model_cls):
+    model_name = model_cls.__name__
+    if model_name not in _lora_model_class:
+        raise ValueError(
+            f"No LoRA variant has been registered for architecture {model_name}."
+        )
+    lora_cfg = _lora_model_config[model_name]
+    return lora_cfg

--- a/tfimm/architectures/timm/poolformer.py
+++ b/tfimm/architectures/timm/poolformer.py
@@ -192,7 +192,6 @@ class PoolFormerBlock(nn.Module):
         use_layer_scale=True,
         layer_scale_init_value=1e-5,
     ):
-
         super().__init__()
 
         self.norm1 = norm_layer(dim)
@@ -315,7 +314,6 @@ class PoolFormer(nn.Module):
         pretrained=None,
         **kwargs,
     ):
-
         super().__init__()
 
         if not fork_feat:


### PR DESCRIPTION
Adding `create_model` function and setting up some form of registry. To create a LoRA model for a supported architecture, use
```
from tfimm.architectures import lora

model = lora.create_model("convnext_tiny", pretrained=True, lora_rank=4)
lora.mark_only_lora_as_trainable(model, train_bias="none")
```