### PR TITLE
Continuing work on model factory

### DIFF
--- a/tfimm/architectures/lora/__init__.py
+++ b/tfimm/architectures/lora/__init__.py
@@ -1,5 +1,9 @@
 from .convnext import *  # noqa: F401
-from .factory import create_model, mark_only_lora_as_trainable  # noqa: F401
+from .factory import (  # noqa: F401
+    convert_to_lora_model,
+    create_model,
+    set_only_lora_layers_trainable,
+)
 from .registry import (  # noqa: F401
     lora_architecture,
     lora_config,

--- a/tfimm/architectures/lora/convnext.py
+++ b/tfimm/architectures/lora/convnext.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
+
+from tfimm.architectures.convnext import ConvNeXt, ConvNeXtConfig
 from tfimm.architectures.lora.layers import LoRADense
-from tfimm.architectures.convnext import ConvNeXtConfig, ConvNeXt
 from tfimm.models import keras_serializable
 
 from .registry import register_lora_architecture
-
 
 __all__ = ["LoRAConvNeXt", "LoRAConvNeXtConfig"]
 

--- a/tfimm/architectures/lora/layers.py
+++ b/tfimm/architectures/lora/layers.py
@@ -2,6 +2,8 @@ import tensorflow as tf
 
 
 class LoRADense(tf.keras.layers.Dense):
+    is_lora_layer: bool = True
+
     def __init__(self, *args, lora_rank: int = 4, lora_alpha: float = 1, **kwargs):
         super().__init__(*args, **kwargs)
         self.lora_rank = lora_rank

--- a/tfimm/architectures/lora/registry.py
+++ b/tfimm/architectures/lora/registry.py
@@ -1,13 +1,14 @@
 import warnings
 
 # These dictionaries contain the mappings from model class to the corresponding LoRA
-# version of the model, i.e., "ConvNeXt" -> LoRAConvNeXt. The keys are the names of the
-# model class, while the values are the class and config class.
+# version of the model, i.e., ConvNeXt -> LoRAConvNeXt. The keys are the model class,
+# while the values are the class and config class.
 #
 # Note that this is different from the model registry in `models/registry.py`, where
 # keys are specific model names, e.g., "convnext_tiny" and the config dictionary
 # contains concrete instances of the configuration classes.
 _lora_model_class = dict()
+_lora_model_base_class = dict()  # Inverse dict to _lora_model_class
 _lora_model_config = dict()
 
 
@@ -15,39 +16,43 @@ def register_lora_architecture(lora_cls):
     # We assume that the LoRA architecture is a subclass of the original model class.
     model_cls = lora_cls.__base__
 
-    model_name = model_cls.__name__
-    if model_name in _lora_model_class:
-        existing_lora_cls = _lora_model_class[model_name]
+    if model_cls in _lora_model_class:
+        existing_lora_cls = _lora_model_class[model_cls]
         warnings.warn(
-            f"Model class {model_name} has already registered a LoRA version "
-            f"{existing_lora_cls.__name__}. Registering {lora_cls.__name__} will "
-            "overwrite this."
+            f"Model class {model_cls} has already registered a LoRA version "
+            f"{existing_lora_cls}. Registering {lora_cls} will overwrite this."
         )
 
     # We assume here that LoRA models have a `cfg_class` class attribute.
     lora_cfg = lora_cls.cfg_class
 
-    _lora_model_class[model_name] = lora_cls
-    _lora_model_config[model_name] = lora_cfg
+    _lora_model_class[model_cls] = lora_cls
+    _lora_model_base_class[lora_cls] = model_cls
+    _lora_model_config[model_cls] = lora_cfg
 
     return lora_cls
 
 
 def lora_architecture(model_cls):
-    model_name = model_cls.__name__
-    if model_name not in _lora_model_class:
+    if model_cls not in _lora_model_class:
         raise ValueError(
-            f"No LoRA variant has been registered for architecture {model_name}."
+            f"No LoRA variant has been registered for architecture {model_cls}."
         )
-    lora_cls = _lora_model_class[model_name]
-    return lora_cls
+    return _lora_model_class[model_cls]
+
+
+def lora_base_architecture(lora_cls):
+    if lora_cls not in _lora_model_base_class:
+        raise ValueError(
+            f"The class {lora_cls} is not registered as the LoRA variant of any "
+            "architecture."
+        )
+    return _lora_model_base_class[lora_cls]
 
 
 def lora_config(model_cls):
-    model_name = model_cls.__name__
-    if model_name not in _lora_model_class:
+    if model_cls not in _lora_model_class:
         raise ValueError(
-            f"No LoRA variant has been registered for architecture {model_name}."
+            f"No LoRA variant has been registered for architecture {model_cls}."
         )
-    lora_cfg = _lora_model_config[model_name]
-    return lora_cfg
+    return _lora_model_config[model_cls]


### PR DESCRIPTION
- Added a function `convert_to_lora_model`, which converts an already existing tf.keras.Model to its LoRA counterpart.
- Renamed `mark_..._as_trainable` to `set_..._as_trainable`. TF uses `set_...` as does tfimm already in various places. It seems the two are synonymous, so we should try to standardise terminology as much as possible.
- The three `..._as_trainable` functions are now called
  - `set_only_lora_layers_trainable` is the function in `factory.py`. This function operates at layer level.
  - `set_only_lora_weights_trainable(train_bias: bool)` in the function we are looking for in LoRA layers. This function operates at weight level.
  - `_set_bias_weights_trainable` is the auxiliary function. No only in the name, since it simply changes the behaviour of bias weights.
- Changed the keys in the LoRA model registry from the name of the class to the class itself, i.e., `ConvNeXt` instead of `"ConvNeXt"`. Turns out types are hashable...
- Added class attribute `is_lora_layer: bool = True` to the `LoRADense` layer. Now we can query for any layer via `getattr(layer, "is_lora_layer", False)` whether it is a LoRA layer or not. It provides for a more uniform querying, regardless of whether we then use the `merge_lora_weights` or `set_only_lora_weights_trainable` methods, or anything else.