### PR TITLE
Lora unit tests

### DIFF
--- a/tests/models/test_lora.py
+++ b/tests/models/test_lora.py
@@ -1,7 +1,9 @@
 import pytest
+import numpy as np
 import tensorflow as tf
 
-from tfimm.architectures import lora
+from tfimm.architectures import lora, ConvNeXt, ConvNeXtConfig
+from tfimm.models import create_model, register_model
 
 # We test both rank 2 and rank 3 inputs, since they use different paths in call().
 @pytest.mark.parametrize("input_shape", [(3, 4), (3, 4, 5)])
@@ -24,3 +26,53 @@ def test_lora_dense(input_shape):
     res_2 = layer(x)
 
     tf.debugging.assert_near(res_1, res_2)
+
+
+@register_model
+def convnext_test_model():
+    cfg = ConvNeXtConfig(
+        name="convnext_test_model",
+        nb_classes=12,
+        input_size=(32, 32),
+        embed_dim=(3, 4, 5, 6),
+        nb_blocks=(1, 1, 1, 1),
+    )
+    return ConvNeXt, cfg
+
+
+def test_convert_to_lora_model():
+    model = create_model("convnext_test_model")
+    lora_model = lora.convert_to_lora_model(model, lora_rank=1)
+
+    img = tf.random.uniform(model.dummy_inputs.shape)
+    res_1 = model(img, training=False)
+    res_2 = lora_model(img, training=False)
+
+    tf.debugging.assert_near(res_1, res_2)
+
+
+def _nb_parameters(model):
+    trainable = np.sum([np.prod(v.get_shape()) for v in model.trainable_weights])
+    non_trainable = np.sum(
+        [np.prod(v.get_shape()) for v in model.non_trainable_weights]
+    )
+    return trainable, non_trainable
+
+
+def test_set_only_lora_layers_trainable():
+    model = tf.keras.Sequential(
+        [
+            tf.keras.layers.Dense(units=2, use_bias=True, name="fc1"),
+            lora.LoRADense(units=3, use_bias=True, lora_rank=3, name="fc2"),
+        ]
+    )
+    model.build(input_shape=(4, 5))
+    # Number of parameters
+    # fc1: kernel 10=5*2, bias 2
+    # fc2: kernel 6=2*3, lora_a 9=3*3, lora_b 6=2*3, bias 3
+
+    # At the beginning everything is trainable
+    assert _nb_parameters(model) == (10 + 2 + 6 + 9 + 6 + 3, 0)
+
+    lora.set_only_lora_layers_trainable(model, train_bias="none")
+    assert _nb_parameters(model) == (9 + 6, 10 + 2 + 6 + 3)

--- a/tests/models/test_lora.py
+++ b/tests/models/test_lora.py
@@ -1,13 +1,14 @@
-
+import pytest
 import tensorflow as tf
 
 from tfimm.architectures import lora
 
-
-def test_lora_dense():
+# We test both rank 2 and rank 3 inputs, since they use different paths in call().
+@pytest.mark.parametrize("input_shape", [(3, 4), (3, 4, 5)])
+def test_lora_dense(input_shape):
     """Creating the layer and running inference in merged and non-merged modes."""
     layer = lora.LoRADense(units=2, use_bias=True, activation="swish")
-    layer.build(input_shape=(3, 4))
+    layer.build(input_shape=input_shape)
     assert not layer.merged
 
     # Set non-trivial weights, since bias and kernel_b are zero-initialised.
@@ -15,7 +16,7 @@ def test_lora_dense():
     layer.kernel_lora_a = tf.random.uniform(layer.kernel_lora_a.shape)
     layer.kernel_lora_b = tf.random.uniform(layer.kernel_lora_b.shape)
 
-    x = tf.random.uniform((3, 4))
+    x = tf.random.uniform(input_shape)
     res_1 = layer(x)
 
     layer.merge_weights()

--- a/tests/models/test_lora.py
+++ b/tests/models/test_lora.py
@@ -1,0 +1,25 @@
+
+import tensorflow as tf
+
+from tfimm.architectures import lora
+
+
+def test_lora_dense():
+    """Creating the layer and running inference in merged and non-merged modes."""
+    layer = lora.LoRADense(units=2, use_bias=True, activation="swish")
+    layer.build(input_shape=(3, 4))
+    assert not layer.merged
+
+    # Set non-trivial weights, since bias and kernel_b are zero-initialised.
+    layer.bias = tf.random.uniform(layer.bias.shape)
+    layer.kernel_lora_a = tf.random.uniform(layer.kernel_lora_a.shape)
+    layer.kernel_lora_b = tf.random.uniform(layer.kernel_lora_b.shape)
+
+    x = tf.random.uniform((3, 4))
+    res_1 = layer(x)
+
+    layer.merge_weights()
+    assert layer.merged
+    res_2 = layer(x)
+
+    tf.debugging.assert_near(res_1, res_2)

--- a/tfimm/architectures/lora/__init__.py
+++ b/tfimm/architectures/lora/__init__.py
@@ -1,6 +1,7 @@
 from .convnext import *  # noqa: F401
 from .factory import (  # noqa: F401
     convert_to_lora_model,
+    convert_to_regular_model,
     create_model,
     lora_non_trainable_weights,
     lora_trainable_weights,
@@ -8,6 +9,7 @@ from .factory import (  # noqa: F401
 from .layers import LoRADense, convert_to_lora_layer  # noqa: F401
 from .registry import (  # noqa: F401
     lora_architecture,
+    lora_base_architecture,
     lora_config,
     register_lora_architecture,
 )

--- a/tfimm/architectures/lora/__init__.py
+++ b/tfimm/architectures/lora/__init__.py
@@ -2,7 +2,8 @@ from .convnext import *  # noqa: F401
 from .factory import (  # noqa: F401
     convert_to_lora_model,
     create_model,
-    set_only_lora_layers_trainable,
+    lora_non_trainable_weights,
+    lora_trainable_weights,
 )
 from .layers import LoRADense  # noqa: F401
 from .registry import (  # noqa: F401

--- a/tfimm/architectures/lora/__init__.py
+++ b/tfimm/architectures/lora/__init__.py
@@ -5,7 +5,7 @@ from .factory import (  # noqa: F401
     lora_non_trainable_weights,
     lora_trainable_weights,
 )
-from .layers import LoRADense  # noqa: F401
+from .layers import LoRADense, convert_to_lora_layer  # noqa: F401
 from .registry import (  # noqa: F401
     lora_architecture,
     lora_config,

--- a/tfimm/architectures/lora/__init__.py
+++ b/tfimm/architectures/lora/__init__.py
@@ -4,6 +4,7 @@ from .factory import (  # noqa: F401
     create_model,
     set_only_lora_layers_trainable,
 )
+from .layers import LoRADense  # noqa: F401
 from .registry import (  # noqa: F401
     lora_architecture,
     lora_config,

--- a/tfimm/architectures/lora/convnext.py
+++ b/tfimm/architectures/lora/convnext.py
@@ -14,7 +14,7 @@ __all__ = ["LoRAConvNeXt", "LoRAConvNeXtConfig"]
 class LoRAConvNeXtConfig(ConvNeXtConfig):
     lora_rank: int = 4
     lora_alpha: float = 1.0
-    train_bias: str = "none"
+    lora_train_bias: str = "none"
     # TODO: lora_dropout
 
 
@@ -42,8 +42,8 @@ class LoRAConvNeXt(ConvNeXt):
 
     @property
     def trainable_weights(self):
-        return lora_trainable_weights(self, train_bias=self.cfg.train_bias)
+        return lora_trainable_weights(self, train_bias=self.cfg.lora_train_bias)
 
     @property
     def non_trainable_weights(self):
-        return lora_non_trainable_weights(self, train_bias=self.cfg.train_bias)
+        return lora_non_trainable_weights(self, train_bias=self.cfg.lora_train_bias)

--- a/tfimm/architectures/lora/convnext.py
+++ b/tfimm/architectures/lora/convnext.py
@@ -4,6 +4,7 @@ from tfimm.architectures.convnext import ConvNeXt, ConvNeXtConfig
 from tfimm.architectures.lora.layers import LoRADense
 from tfimm.models import keras_serializable
 
+from .factory import lora_non_trainable_weights, lora_trainable_weights
 from .registry import register_lora_architecture
 
 __all__ = ["LoRAConvNeXt", "LoRAConvNeXtConfig"]
@@ -13,6 +14,7 @@ __all__ = ["LoRAConvNeXt", "LoRAConvNeXtConfig"]
 class LoRAConvNeXtConfig(ConvNeXtConfig):
     lora_rank: int = 4
     lora_alpha: float = 1.0
+    train_bias: str = "none"
     # TODO: lora_dropout
 
 
@@ -20,15 +22,15 @@ class LoRAConvNeXtConfig(ConvNeXtConfig):
 @register_lora_architecture
 class LoRAConvNeXt(ConvNeXt):
     cfg_class = LoRAConvNeXtConfig
-    keys_to_ignore_on_load_missing = ["kernel_lora"]
 
     def __init__(self, cfg: LoRAConvNeXtConfig, **kwargs):
         # We first create the original model
         super().__init__(cfg, **kwargs)
+        self.cfg = cfg
 
+        # Then we replace all the layers we want to replace. Here we only replace the
+        # 1x1 convolutions in MLP blocks.
         lora_cfg = {"lora_rank": cfg.lora_rank, "lora_alpha": cfg.lora_alpha}
-
-        # Then we replace all the layers we want to replace
         for stage in self.stages:
             for block in stage.blocks:
                 layer_config = block.mlp.fc1.get_config()
@@ -38,12 +40,10 @@ class LoRAConvNeXt(ConvNeXt):
                 layer_config.update(lora_cfg)
                 block.mlp.fc2 = LoRADense.from_config(layer_config)
 
-    def merge_lora_weights(self):
-        for layer in self._flatten_layers(recursive=True, include_self=False):
-            if hasattr(layer, "merge_lora_weights"):
-                layer.merge_lora_weights()
+    @property
+    def trainable_weights(self):
+        return lora_trainable_weights(self, train_bias=self.cfg.train_bias)
 
-    def unmerge_lora_weights(self):
-        for layer in self._flatten_layers(recursive=True, include_self=False):
-            if hasattr(layer, "unmerge_lora_weights"):
-                layer.unmerge_lora_weights()
+    @property
+    def non_trainable_weights(self):
+        return lora_non_trainable_weights(self, train_bias=self.cfg.train_bias)

--- a/tfimm/architectures/lora/convnext.py
+++ b/tfimm/architectures/lora/convnext.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
 
 from tfimm.architectures.convnext import ConvNeXt, ConvNeXtConfig
-from tfimm.architectures.lora.layers import LoRADense
 from tfimm.models import keras_serializable
 
 from .factory import lora_non_trainable_weights, lora_trainable_weights
+from .layers import convert_to_lora_layer
 from .registry import register_lora_architecture
 
 __all__ = ["LoRAConvNeXt", "LoRAConvNeXtConfig"]
@@ -33,12 +33,8 @@ class LoRAConvNeXt(ConvNeXt):
         lora_cfg = {"lora_rank": cfg.lora_rank, "lora_alpha": cfg.lora_alpha}
         for stage in self.stages:
             for block in stage.blocks:
-                layer_config = block.mlp.fc1.get_config()
-                layer_config.update(lora_cfg)
-                block.mlp.fc1 = LoRADense.from_config(layer_config)
-                layer_config = block.mlp.fc2.get_config()
-                layer_config.update(lora_cfg)
-                block.mlp.fc2 = LoRADense.from_config(layer_config)
+                block.mlp.fc1 = convert_to_lora_layer(block.mlp.fc1, **lora_cfg)
+                block.mlp.fc2 = convert_to_lora_layer(block.mlp.fc2, **lora_cfg)
 
     @property
     def trainable_weights(self):

--- a/tfimm/architectures/lora/factory.py
+++ b/tfimm/architectures/lora/factory.py
@@ -101,7 +101,7 @@ def convert_to_lora_model(model: tf.keras.Model, **kwargs) -> tf.keras.Model:
         src_model=model, dst_model=lora_model, weights_to_ignore=LORA_WEIGHT_NAMES
     )
 
-    return model
+    return lora_model
 
 
 def convert_to_regular_model(model: tf.keras.Model) -> tf.keras.Model:
@@ -124,7 +124,7 @@ def convert_to_regular_model(model: tf.keras.Model) -> tf.keras.Model:
     cfg = model.cfg
     base_cfg_fields = {f.name for f in dataclasses.fields(base_cfg_cls)}
     base_cfg = base_cfg_cls(
-        **{k: v for k, v in dataclasses.asdict(cfg) if k in base_cfg_fields}
+        **{k: v for k, v in dataclasses.asdict(cfg).items() if k in base_cfg_fields}
     )
 
     # Then create the base model, build it and transfer weights to it.

--- a/tfimm/architectures/lora/factory.py
+++ b/tfimm/architectures/lora/factory.py
@@ -13,7 +13,7 @@ from .registry import lora_architecture, lora_base_architecture, lora_config
 
 # List of patterns to match LoRA weights, so they can be excluded from weight transfers
 # between a model and its LoRA version.
-LORA_WEIGHT_NAMES = ["lora_weight"]
+LORA_WEIGHT_NAMES = ["kernel_lora_a", "kernel_lora_b"]
 
 
 def create_model(
@@ -137,7 +137,7 @@ def convert_to_regular_model(model: tf.keras.Model) -> tf.keras.Model:
         model._flatten_layers(recursive=True, include_self=False)
     ):
         if getattr(layer, "is_lora_layer", False) and not layer.merged:
-            layer.merge_lora_weights()
+            layer.merge_weights()
             merge_indices.add(idx)
 
     # Drum roll... Weight transfer happening here.
@@ -149,7 +149,7 @@ def convert_to_regular_model(model: tf.keras.Model) -> tf.keras.Model:
     ):
         if idx in merge_indices:
             assert getattr(layer, "is_lora_layer", False)
-            layer.unmerge_lora_weights()
+            layer.unmerge_weights()
 
     return base_model
 

--- a/tfimm/architectures/lora/layers.py
+++ b/tfimm/architectures/lora/layers.py
@@ -138,8 +138,9 @@ def convert_to_lora_layer(
     Returns:
         LoRA layer instance.
     """
-    if type(layer) is tf.keras.layers.Dense:
-        lora_layer = LoRADense(**layer.get_config(), **kwargs)
+    layer_lookup = {tf.keras.layers.Dense: LoRADense}
+    if type(layer) in layer_lookup:
+        lora_layer = layer_lookup[type(layer)](**layer.get_config(), **kwargs)
     else:
         raise ValueError(
             f"Unsupported layer type for conversion to LoRA: {type(layer)}."

--- a/tfimm/architectures/lora/layers.py
+++ b/tfimm/architectures/lora/layers.py
@@ -117,13 +117,8 @@ class LoRADense(tf.keras.layers.Dense):
         self.kernel.assign_add(-self.kernel_lora_a @ self.kernel_lora_b * self.scaling)
         self.merged = False
 
-    def set_only_lora_weights_trainable(self, train_bias: bool):
-        self.kernel = tf.Variable(self.kernel, trainable=False, name=self.kernel.name)
-        self.kernel_lora_a = tf.Variable(
-            self.kernel_lora_a, trainable=True, name=self.kernel_lora_a.name
-        )
-        self.kernel_lora_b = tf.Variable(
-            self.kernel_lora_b, trainable=True, name=self.kernel_lora_b.name
-        )
-        if not train_bias:
-            self.bias = tf.Variable(self.bias, trainable=False, name=self.bias.name)
+    def lora_trainable_weights(self, train_bias: bool):
+        trainable_variables = [self.kernel_lora_a, self.kernel_lora_b]
+        if train_bias and self.use_bias:
+            trainable_variables += [self.bias]
+        return trainable_variables

--- a/tfimm/architectures/lora/layers.py
+++ b/tfimm/architectures/lora/layers.py
@@ -122,3 +122,26 @@ class LoRADense(tf.keras.layers.Dense):
         if train_bias and self.use_bias:
             trainable_variables += [self.bias]
         return trainable_variables
+
+
+def convert_to_lora_layer(
+    layer: tf.keras.layers.Layer, **kwargs
+) -> tf.keras.layers.Layer:
+    """
+    Convenience function to convert supported layer types to their LoRA counterparts.
+
+    Args:
+        layer: Layer to be converted.
+        **kwargs: LoRA specific parameters such as ``lora_rank`` have to be passed as
+            kwargs.
+
+    Returns:
+        LoRA layer instance.
+    """
+    if type(layer) is tf.keras.layers.Dense:
+        lora_layer = LoRADense(**layer.get_config(), **kwargs)
+    else:
+        raise ValueError(
+            f"Unsupported layer type for conversion to LoRA: {type(layer)}."
+        )
+    return lora_layer


### PR DESCRIPTION
In addition to adding unit tests I have made the following changes.
- In `LoRADense`, replaced `*args` in `__init__` with an explicit list of parameters. The public TF API is fairly stable and for code inspection it is easier if the PyCharm tooltip shows you the list of parameters.
- In `LoRADense`, renamed `merge_lora_weights()` and `unmerge_lora_weights()` to `merge_weights()` and `unmerge_weights()`. I don't think it is necessary to repeat `lora` here. If possible and within reason, simpler names are preferable.
- In `LoRADense.call()`, moved the `if self.merged:` check to the very beginning of the function, before casting happens. In the merged case we hand everything to the base class.
- Fixed the `LORA_WEIGHT_NAMES` list in `factory.py`.
- Added a `convert_to_lora_layer` helper function to make creating LoRA layers easier.