### PR TITLE
Add option to load weights from huggingface hub directly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unpublished
+
+- Added support for loading pytorch models from HF hub via URL prefix `[hf-pytorch]`.
+
 ## v0.2.14 - 2023-05-15
 
 - Added support for LoRA training.

--- a/README.md
+++ b/README.md
@@ -201,10 +201,12 @@ The following architectures are currently available:
   [\[github\]](https://github.com/facebookresearch/segment-anything)
     - Segment Anything [\[arXiv:2304.02643\]](https://arxiv.org/abs/2304.02643)
 
-### Using pre-trained models from the huggingface hub
-It is possible to load pre-trained model weights from the huggingface hub.
-See the [huggingface-model-weights](notebooks/huggingface-model-weights.ipynb) notebook for details.
-For this to work, it is important that the weight names and shapes on huggingface are compatible with once of the tfimm model configurations.
+### Loading pytorch models from HF hub
+
+It is possible to load pre-trained model weights from the HF hub. See the 
+[huggingface-model-weights](notebooks/huggingface-model-weights.ipynb) notebook for 
+details. For this to work, it is important that the weight names and shapes on 
+HF hub are compatible with one of the `tfimm` model configurations.
 
 ## Profiling
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,11 @@ The following architectures are currently available:
   [\[github\]](https://github.com/facebookresearch/segment-anything)
     - Segment Anything [\[arXiv:2304.02643\]](https://arxiv.org/abs/2304.02643)
 
+### Using pre-trained models from the huggingface hub
+It is possible to load pre-trained model weights from the huggingface hub.
+See the [huggingface-model-weights](notebooks/huggingface-model-weights.ipynb) notebook for details.
+For this to work, it is important that the weight names and shapes on huggingface are compatible with once of the tfimm model configurations.
+
 ## Profiling
 
 To understand how big each of the models is, I have done some profiling to measure

--- a/notebooks/huggingface-model-weights.ipynb
+++ b/notebooks/huggingface-model-weights.ipynb
@@ -1,0 +1,192 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a66f18ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import timm\n",
+    "import tfimm\n",
+    "\n",
+    "from tfimm.models import register_model\n",
+    "from tfimm.architectures.vit import ViTConfig, ViT"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "122cc937",
+   "metadata": {},
+   "source": [
+    "## Creating models with weights from huggingface"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02bb9c6a-3e41-42b1-9d73-e96997df5bb8",
+   "metadata": {},
+   "source": [
+    "Make sure to pre-pend the `url` with [hf] and to also specify the file_name (e.g. `pytorch_model.bin`) in the url - see the examples below:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13b3c0e2",
+   "metadata": {},
+   "source": [
+    "### Loading timm models from huggingface"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "62170474",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "@register_model\n",
+    "def vit_small_patch16_224_augreg_in1k_hf():\n",
+    "    \"\"\"ViT-Small (ViT-S/16)\"\"\"\n",
+    "    cfg = ViTConfig(\n",
+    "        name=\"vit_small_patch16_224_augreg_in1k_hf\",\n",
+    "        url=\"[hf]timm/vit_small_patch16_224.augreg_in1k/pytorch_model.bin\",\n",
+    "        patch_size=16,\n",
+    "        embed_dim=384,\n",
+    "        nb_blocks=12,\n",
+    "        nb_heads=6,\n",
+    "    )\n",
+    "    return ViT, cfg"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "45b9c36b",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "url: timm/vit_small_patch16_224.augreg_in1k\n",
+      "file_name: pytorch_model.bin\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "All PyTorch model weights were used when initializing ViT.\n",
+      "All the weights of ViT were initialized from the PyTorch model.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "model = tfimm.create_model(\"vit_small_patch16_224_augreg_in1k_hf\", pretrained=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "156d6f4b-8965-4e4e-8587-7ad4e5a01a75",
+   "metadata": {},
+   "source": [
+    "### Loading fine-tuned models from huggingface the huggingface hub"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bdffcb99-6ea1-423d-a098-8dfb13b0218d",
+   "metadata": {},
+   "source": [
+    "#### Here we dowload a model that was fine-tuned on cifar100 by one of the hf users"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "2300684d-3950-4691-bd98-f0262d9f7a17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@register_model\n",
+    "def vit_base_patch16_224_in21k_ft_cifar100():\n",
+    "    \"\"\"\n",
+    "    ViT-Base (ViT-B/16) from original paper (https://arxiv.org/abs/2010.11929).\n",
+    "    \"\"\"\n",
+    "    cfg = ViTConfig(\n",
+    "        name=\"vit_base_patch16_224_in21k_ft_cifar100\",\n",
+    "        url=\"[hf]edadaltocg/vit_base_patch16_224_in21k_ft_cifar100/pytorch_model.bin\",\n",
+    "        patch_size=16,\n",
+    "        embed_dim=768,\n",
+    "        nb_blocks=12,\n",
+    "        nb_heads=12,\n",
+    "        nb_classes=100,\n",
+    "    )\n",
+    "    return ViT, cfg"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "921bcfbc-9ebe-46f7-8d88-d08628f902e5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "url: edadaltocg/vit_base_patch16_224_in21k_ft_cifar100\n",
+      "file_name: pytorch_model.bin\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "All PyTorch model weights were used when initializing ViT.\n",
+      "All the weights of ViT were initialized from the PyTorch model.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "model = tfimm.create_model(\"vit_base_patch16_224_in21k_ft_cifar100\", pretrained=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36c819aa-3594-4334-864f-790314e6cd57",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.17"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tfimm/models/factory.py
+++ b/tfimm/models/factory.py
@@ -75,8 +75,8 @@ def create_model(
             loaded_model(loaded_model.dummy_inputs)
             load_pth_url_weights(loaded_model, url)
 
-        elif cfg.url.startswith("[hf-pytorch]"):
-            url = cfg.url[len("[hf-pytorch]") :]
+        elif cfg.url.startswith("[hf]"):
+            url = cfg.url[len("[hf]") :]
             loaded_model = cls(cfg)
             loaded_model(loaded_model.dummy_inputs)
             load_hf_hub_weights(loaded_model, url)

--- a/tfimm/models/factory.py
+++ b/tfimm/models/factory.py
@@ -7,7 +7,12 @@ import tensorflow as tf
 from tensorflow.python.keras import backend as K
 
 from tfimm.models.registry import is_model, model_class, model_config
-from tfimm.utils import cached_model_path, load_pth_url_weights, load_timm_weights
+from tfimm.utils import (
+    cached_model_path,
+    load_hf_hub_weights,
+    load_pth_url_weights,
+    load_timm_weights,
+)
 
 
 def create_model(
@@ -69,6 +74,12 @@ def create_model(
             loaded_model = cls(cfg)
             loaded_model(loaded_model.dummy_inputs)
             load_pth_url_weights(loaded_model, url)
+
+        elif cfg.url.startswith("[hf-pytorch]"):
+            url = cfg.url[len("[hf-pytorch]") :]
+            loaded_model = cls(cfg)
+            loaded_model(loaded_model.dummy_inputs)
+            load_hf_hub_weights(loaded_model, url)
         else:
             raise NotImplementedError(
                 "Model not found in cache. Download of weights only implemented for "

--- a/tfimm/models/factory.py
+++ b/tfimm/models/factory.py
@@ -9,7 +9,7 @@ from tensorflow.python.keras import backend as K
 from tfimm.models.registry import is_model, model_class, model_config
 from tfimm.utils import (
     cached_model_path,
-    load_hf_hub_weights,
+    load_hf_pytorch_hub_weights,
     load_pth_url_weights,
     load_timm_weights,
 )
@@ -75,11 +75,11 @@ def create_model(
             loaded_model(loaded_model.dummy_inputs)
             load_pth_url_weights(loaded_model, url)
 
-        elif cfg.url.startswith("[hf]"):
-            url = cfg.url[len("[hf]") :]
+        elif cfg.url.startswith("[hf-pytorch]"):
+            url = cfg.url[len("[hf-pytorch]") :]
             loaded_model = cls(cfg)
             loaded_model(loaded_model.dummy_inputs)
-            load_hf_hub_weights(loaded_model, url)
+            load_hf_pytorch_hub_weights(loaded_model, url)
         else:
             raise NotImplementedError(
                 "Model not found in cache. Download of weights only implemented for "

--- a/tfimm/utils/__init__.py
+++ b/tfimm/utils/__init__.py
@@ -9,7 +9,7 @@ from .cache import (  # noqa: F401
 from .constants import *  # noqa: F401
 from .etc import make_divisible, to_2tuple  # noqa: F401
 from .timm import (  # noqa: F401
-    load_hf_hub_weights,
+    load_hf_pytorch_hub_weights,
     load_pth_url_weights,
     load_timm_weights,
 )

--- a/tfimm/utils/__init__.py
+++ b/tfimm/utils/__init__.py
@@ -8,4 +8,8 @@ from .cache import (  # noqa: F401
 )
 from .constants import *  # noqa: F401
 from .etc import make_divisible, to_2tuple  # noqa: F401
-from .timm import load_pth_url_weights, load_timm_weights  # noqa: F401
+from .timm import (  # noqa: F401
+    load_hf_hub_weights,
+    load_pth_url_weights,
+    load_timm_weights,
+)

--- a/tfimm/utils/timm.py
+++ b/tfimm/utils/timm.py
@@ -247,6 +247,12 @@ def load_timm_weights(model: tf.keras.Model, model_name: str):
     load_pytorch_weights_in_tf2_model(model, pt_state_dict)
 
 
+def split_url_filename(url: str):
+    """Split provided url into url and file_name."""
+    parts = url.split("/")
+    return ("/").join(parts[:-1]), parts[-1]
+
+
 def load_hf_hub_weights(model: tf.keras.Model, url: str):
     """Loads weights from hugging face."""
     try:
@@ -255,7 +261,10 @@ def load_hf_hub_weights(model: tf.keras.Model, url: str):
         logging.error("To load weights from hf hub, timm needs to be installed.")
         raise
 
-    pt_state_dict = load_state_dict_from_hf(model_id=url, filename="pytorch_model.bin")
+    url, file_name = split_url_filename(url)
+    print(f"url: {url}")
+    print(f"file_name: {file_name}")
+    pt_state_dict = load_state_dict_from_hf(model_id=url, filename=file_name)
     load_pytorch_weights_in_tf2_model(model, pt_state_dict)
 
 

--- a/tfimm/utils/timm.py
+++ b/tfimm/utils/timm.py
@@ -247,6 +247,18 @@ def load_timm_weights(model: tf.keras.Model, model_name: str):
     load_pytorch_weights_in_tf2_model(model, pt_state_dict)
 
 
+def load_hf_hub_weights(model: tf.keras.Model, url: str):
+    """Loads weights from hugging face."""
+    try:
+        from timm.models._hub import load_state_dict_from_hf
+    except ImportError:
+        logging.error("To load weights from hf hub, timm needs to be installed.")
+        raise
+
+    pt_state_dict = load_state_dict_from_hf(model_id=url, filename="pytorch_model.bin")
+    load_pytorch_weights_in_tf2_model(model, pt_state_dict)
+
+
 def load_pth_url_weights(model: tf.keras.Model, url: str):
     """Loads weights from a PyTorch .pth file specified by URL."""
     try:


### PR DESCRIPTION
This PR adds the ability to load weights for existing models directly from the hugging face hub. This need arises for example if there are interesting new pre-trained or fine-tuned model weights available on the hugging face hub that are not yet available directly in tfimm.